### PR TITLE
fix: update goreleaser flag to --clean and update codecov to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,10 @@ jobs:
           go test -race -coverprofile=coverage.txt -covermode=atomic ./...
         if: matrix.mysql == 8
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         if: matrix.mysql == 8
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   primaryreplica:
     name: Primary Replica

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
       - name: Start mysql containers
-        run: docker-compose -f "docker-compose.yml" up -d --build
+        run: docker compose -f "docker-compose.yml" up -d --build
       - name: Test
         env:
           TEST_PRIMARY_REPLICA: 'true'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   mariadb-master:
-    image: docker.io/bitnami/mariadb:10.6
+    image: docker.io/bitnamilegacy/mariadb:10.6
     ports:
       - '23306:3306'
     environment:
@@ -20,7 +20,7 @@ services:
       retries: 6
 
   mariadb-slave:
-    image: docker.io/bitnami/mariadb:10.6
+    image: docker.io/bitnamilegacy/mariadb:10.6
     ports:
       - '23307:3306'
     depends_on:


### PR DESCRIPTION
Replaces the deprecated --rm-dist flag with --clean in the release workflow, and updates codecov/codecov-action to v7 with token authentication.